### PR TITLE
Update wcf_test.go 解决监听消息无返回

### DIFF
--- a/wcf/wcf_test.go
+++ b/wcf/wcf_test.go
@@ -173,6 +173,8 @@ func TestOnMSG(t *testing.T) {
 	defer func() {
 		logs.Info(wcf.DisableRecvTxt())
 	}()
+	// 设置监听状态开启 否则会出现无消息返回
+	wcf.RecvTxt = true
 	go wcf.OnMSG(func(msg *WxMsg) {
 		logs.Info(msg.GetContent())
 	})


### PR DESCRIPTION
原因是RecvTxt = true设置未生效 这里在使用的时候最好是再配置一下

虽然EnableRecvTxt方法里配置了RecvTxt = true 但是无效 目前先在demo里手动RecvTxt = true解决无消息返回问题