### PR TITLE
Update wcf.go 彻底修复客户端监听消息无效问题

### DIFF
--- a/wcf/wcf.go
+++ b/wcf/wcf.go
@@ -666,7 +666,6 @@ func (c *Client) EnableRecvTxt() int32 {
 	if err != nil {
 		logs.Err(err)
 	}
-	c.RecvTxt = true
 	return recv.GetStatus()
 }
 func (c *Client) DisableRecvTxt() int32 {
@@ -682,6 +681,7 @@ func (c *Client) DisableRecvTxt() int32 {
 	return recv.GetStatus()
 }
 func (c *Client) OnMSG(f func(msg *WxMsg)) error {
+	c.RecvTxt = true
 	socket, err := pair1.NewSocket()
 	if err != nil {
 		return err


### PR DESCRIPTION
c.RecvTxt = true改至OnMSG方法生效 解决了监听失败问题